### PR TITLE
Fixed toast error messages on iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-native-scrollable-tab-view": "^1.0.0",
     "react-native-svg": "9.13.3",
     "react-native-swiper": "^1.5.14",
+    "react-native-tiny-toast": "^1.0.6",
     "react-native-vector-icons": "^6.6.0",
     "react-native-web": "^0.12.0-rc.1",
     "react-navigation": "^4.0.10",

--- a/src/events/EventsManager.js
+++ b/src/events/EventsManager.js
@@ -1,6 +1,7 @@
 // Use this class to interact with all of the events, never modify the state directly
 
-import { AsyncStorage, ToastAndroid as Toast } from "react-native";
+import { AsyncStorage} from "react-native";
+import Toast from "react-native-tiny-toast";
 // import firebase from "firebase";
 import moment from "moment";
 import _ from "lodash";

--- a/src/events/EventsManager.js
+++ b/src/events/EventsManager.js
@@ -1,6 +1,6 @@
 // Use this class to interact with all of the events, never modify the state directly
 
-import { AsyncStorage} from "react-native";
+import { AsyncStorage } from "react-native";
 import Toast from "react-native-tiny-toast";
 // import firebase from "firebase";
 import moment from "moment";

--- a/src/screens/Mentors.jsx
+++ b/src/screens/Mentors.jsx
@@ -8,8 +8,8 @@ import {
   TextInput,
   TouchableOpacity,
   View,
-  ToastAndroid as Toast,
 } from "react-native";
+import Toast from "react-native-tiny-toast";
 // import firebase from "firebase";
 import AltModalHeader from "../components/modals/AltModalHeader";
 import { Button, PadContainer, ViewContainer } from "../components/Base";


### PR DESCRIPTION
Fixes #6 

Fix includes a new library "react-native-tiny-toast" which has support for iOS versus react-native's ToastAndroid component. 