### PR TITLE
You can now specify the data that mockFetch() returns

### DIFF
--- a/src/events/EventsManager.js
+++ b/src/events/EventsManager.js
@@ -5,6 +5,9 @@ import Toast from "react-native-tiny-toast";
 import * as Permissions from "expo-permissions";
 import moment from "moment";
 import _ from "lodash";
+import mockSchedule from "../mockData/mockSchedule";
+import mockFavoriteCounts from "../mockData/mockFavoriteCounts";
+import mockUser from "../mockData/mockUser";
 
 import { createEventDay } from "./utils";
 import mockFetch from "../mockData/mockFetch";
@@ -56,7 +59,7 @@ export default class EventsManager {
       // firebase.database().ref('/Schedule')
       //   .on('value', async (snapshot) => {
       // let data = snapshot.val();
-      mockFetch("schedule")
+      mockFetch("schedule", mockSchedule)
         .then(responseData => responseData.json())
         .then(data => {
           // store new schedule on phone
@@ -152,7 +155,10 @@ export default class EventsManager {
   }
 
   fetchSavedCounts() {
-    mockFetch("https://api.bit.camp/api/firebaseEvents/favoriteCounts")
+    mockFetch(
+      "https://api.bit.camp/api/firebaseEvents/favoriteCounts",
+      mockFavoriteCounts
+    )
       .then(response => response.json())
       .then(responseJson => {
         const newSavedCount = responseJson;
@@ -189,6 +195,7 @@ export default class EventsManager {
         const { id } = resultObj;
         const response = await mockFetch(
           `https://api.bit.camp/api/users/${id}/`,
+          mockUser,
           {
             method: "GET",
             headers: {
@@ -275,6 +282,7 @@ export default class EventsManager {
         const { id } = JSON.parse(result);
         mockFetch(
           `https://api.bit.camp/api/users/${id}/favoriteFirebaseEvent/${eventID}`,
+          null,
           {
             method: "POST",
             headers: {
@@ -329,6 +337,7 @@ export default class EventsManager {
 
         mockFetch(
           `https://api.bit.camp/api/users/${id}/unfavoriteFirebaseEvent/${eventID}`,
+          null,
           {
             method: "POST",
             headers: {

--- a/src/mockData/mockFetch.js
+++ b/src/mockData/mockFetch.js
@@ -1,104 +1,20 @@
-import mockSchedule from "./mockSchedule";
-import mockFavoriteCounts from "./mockFavoriteCounts";
-import mockUser from "./mockUser";
-import mockQuestions from "./mockQuestions";
-
 /**
  * A stand-in for the standard fetch() function that returns a barebones
  * API response using dummy data.
  *
  * TODO: phase this function out once the app's backend is setup
  *
- * @param {*} uri The data you want to retrieve
+ * @param {*} url The fetch location (currently unused)
+ * @param {*} resData The data you want the code to respond with
  * @param {*} options The options (currently unused)
  * @returns a promise that returns a Response object with a 200 status.
  * To access the response data, call the object's .json() method
  */
-const mockFetch = async uri => {
-  try {
-    const respData = getResponse(uri);
-    return {
-      json: async () => respData,
-      status: 200,
-      statusText: "OK",
-      ok: true,
-    };
-  } catch (e) {
-    return null;
-  }
-};
-
-// These objects store the different types
-const apiURL = "https://api.bit.camp";
-const questionServerURL = "https://guarded-brook-59345.herokuapp.com";
-const requestTypes = {
-  getUser: {
-    uriPattern: new RegExp(`${apiURL}/api/users/\\d+/?`),
-    data: mockUser,
-  },
-  favoriteEvent: {
-    uriPattern: new RegExp(
-      `${apiURL}/api/users/\\d+/favoriteFirebaseEvent/\\d+/?`
-    ),
-    data: mockFavoriteCounts,
-  },
-  unfavoriteEvent: {
-    uriPattern: new RegExp(
-      `${apiURL}/api/users/\\d+/unfavoriteFirebaseEvent/\\d+/?`
-    ),
-    data: mockFavoriteCounts,
-  },
-  favoriteCounts: {
-    uriPattern: new RegExp(`${apiURL}/api/firebaseEvents/favoriteCounts/?`),
-    data: mockFavoriteCounts,
-  },
-  requestEmailCode: {
-    uriPattern: new RegExp(`${apiURL}/auth/login/requestCode/?`),
-    data: {}, // No data needed (getting a 200 status code will run the correct logic)
-  },
-  submitEmailCode: {
-    uriPattern: new RegExp(`${apiURL}/auth/login/code/?`),
-    data: {
-      user: mockUser,
-      token: "test",
-    },
-  },
-  getQuestions: {
-    uriPattern: new RegExp(`${questionServerURL}/getquestions/.+@.+\\..+/?`),
-    data: mockQuestions,
-  },
-  submitQuestion: {
-    uriPattern: new RegExp(`${questionServerURL}/question/?`),
-    data: {}, // No data needed (getting a 200 status code will run the correct logic)
-  },
-  checkInWithQRCode: {
-    uriPattern: new RegExp(`${apiURL}/api/users/.+/checkIn/?`),
-    data: mockUser,
-  },
-  schedule: {
-    uriPattern: /schedule/,
-    data: mockSchedule,
-  },
-};
-
-/**
- * Gives back the response data corresponding to the supplied URI
- * @param uri The URI of the API call
- * @returns The data corresponding to the given URI
- */
-const getResponse = uri => {
-  // Go through all request types and return the corresponding data
-  const types = Object.keys(requestTypes);
-  for (let i = 0; i < types.length; i += 1) {
-    const request = requestTypes[types[i]];
-
-    if (request.uriPattern.test(uri)) {
-      return request.data;
-    }
-  }
-
-  // Otherwise, print that there was an error
-  throw new Error(`Unsupported Request URI: ${uri}`);
-};
-
-export default mockFetch;
+export default async function mockFetch(url, respData) {
+  return {
+    json: async () => respData,
+    status: 200,
+    statusText: "OK",
+    ok: true,
+  };
+}

--- a/src/screens/Login.jsx
+++ b/src/screens/Login.jsx
@@ -9,6 +9,7 @@ import { BaseText } from "../components/Text";
 import colors from "../components/Colors";
 import KeyboardShift from "../components/KeyboardShift";
 import mockFetch from "../mockData/mockFetch";
+import mockUser from "../mockData/mockUser";
 
 const APP_ID = "@com.technica.technica18:";
 const USER_TOKEN = `${APP_ID}JWT`;
@@ -51,7 +52,7 @@ export default class Login extends Component {
       const token = await Notifications.getExpoPushTokenAsync();
 
       try {
-        mockFetch(EXPO_ENDPOINT, {
+        mockFetch(EXPO_ENDPOINT, null, {
           method: "POST",
           headers: {
             Accept: "application/json",
@@ -90,7 +91,7 @@ export default class Login extends Component {
     if (Login.isValidEmail(email)) {
       const url = "https://api.bit.camp/auth/login/requestCode";
       try {
-        const response = await mockFetch(url, {
+        const response = await mockFetch(url, null, {
           method: "POST",
           headers: {
             Accept: "application/json",
@@ -135,7 +136,7 @@ export default class Login extends Component {
     const url = "https://api.bit.camp/auth/login/code";
     try {
       const email = savedEmail;
-      const response = await mockFetch(url, {
+      const response = await mockFetch(url, mockUser, {
         method: "POST",
         headers: {
           Accept: "application/json",

--- a/src/screens/Mentors.jsx
+++ b/src/screens/Mentors.jsx
@@ -12,6 +12,7 @@ import QuestionCard from "../components/QuestionCard";
 import { H2, P } from "../components/Text";
 import { scale } from "../utils/scale";
 import mockFetch from "../mockData/mockFetch";
+import mockQuestions from "../mockData/mockQuestions";
 import { questionType } from "../utils/PropTypeUtils";
 
 // TODO: move to somewhere central
@@ -54,7 +55,7 @@ export default class Mentors extends Component {
   }
 
   async grabQuestionsFromDB(email) {
-    mockFetch(`${serverURL}/getquestions/${email}`, {
+    mockFetch(`${serverURL}/getquestions/${email}`, mockQuestions, {
       method: "GET",
       headers: {
         Accept: "application/json",

--- a/src/screens/modals/QuestionModal.jsx
+++ b/src/screens/modals/QuestionModal.jsx
@@ -86,7 +86,7 @@ export default class QuestionModal extends Component {
       }
 
       const questionString = JSON.stringify(questionObject);
-      mockFetch(`${serverURL}/question`, {
+      mockFetch(`${serverURL}/question`, null, {
         method: "POST",
         headers: {
           Accept: "application/json",


### PR DESCRIPTION
Closes #18 . Now, every time you call `mockFetch()`, you have to specify what data you want to be returned. This is an improvement from before, where the URL you were fetching from had to pass a regex in order to return the desired data.